### PR TITLE
Config to disable villager trading

### DIFF
--- a/src/main/java/com/killerqu/packtweaker/PackTweaker.java
+++ b/src/main/java/com/killerqu/packtweaker/PackTweaker.java
@@ -3,7 +3,10 @@ package com.killerqu.packtweaker;
 import com.killerqu.packtweaker.config.ClientConfig;
 import com.killerqu.packtweaker.config.CommonConfig;
 import com.mojang.logging.LogUtils;
+import net.minecraft.world.entity.npc.Villager;
+import net.minecraft.world.entity.npc.WanderingTrader;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.VillagerTradingManager;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
@@ -13,12 +16,13 @@ import org.slf4j.Logger;
 @Mod(PackTweaker.MODID)
 public class PackTweaker {
     public static final String MODID = "packtweaker";
-    private static final Logger LOGGER = LogUtils.getLogger();
+    public static final Logger LOGGER = LogUtils.getLogger();
 
     public PackTweaker() {
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, CommonConfig.SPEC);
         ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ClientConfig.SPEC);
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
         MinecraftForge.EVENT_BUS.register(this);
+
     }
 }

--- a/src/main/java/com/killerqu/packtweaker/config/CommonConfig.java
+++ b/src/main/java/com/killerqu/packtweaker/config/CommonConfig.java
@@ -11,6 +11,7 @@ public class CommonConfig {
     public static final ForgeConfigSpec.ConfigValue<Boolean> ENABLE_SLEEP;
     public static final ForgeConfigSpec.ConfigValue<Boolean> ENABLE_HUNGER;
     public static final ForgeConfigSpec.ConfigValue<Integer> CONSTANT_HUNGER_VALUE;
+    public static final ForgeConfigSpec.ConfigValue<Boolean> ENABLE_TRADING;
     static {
         BUILDER.push("PackTweaker config");
 
@@ -22,6 +23,8 @@ public class CommonConfig {
                 .define("Enable Hunger", true);
         CONSTANT_HUNGER_VALUE = BUILDER.comment("If hunger was disabled, this amount will be used as your hunger value.")
                 .define("Constant Hunger Value", 18);
+        ENABLE_TRADING = BUILDER.comment("If false, trading with villagers is disabled. The list of trades is unaffected, as is the rank of the villager. Wandering traders are unaffected, use gamerules to disable them.")
+                .define("Enable Villager Trading", true);
 
         BUILDER.pop();
         SPEC = BUILDER.build();

--- a/src/main/java/com/killerqu/packtweaker/mixin/VillagerTradesMixin.java
+++ b/src/main/java/com/killerqu/packtweaker/mixin/VillagerTradesMixin.java
@@ -1,0 +1,26 @@
+package com.killerqu.packtweaker.mixin;
+
+import com.killerqu.packtweaker.config.CommonConfig;
+import net.minecraft.world.entity.npc.Villager;
+import net.minecraft.world.item.trading.MerchantOffers;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+//This mixin disables trading with a villagers by making it think it has no trades.
+//It does not touch the actual trades list and is controlled by a config.
+@Mixin(Villager.class)
+public class VillagerTradesMixin {
+    //This is the list that gets swapped in.
+    @Unique
+    private static MerchantOffers packTweaker$EMPTY = new MerchantOffers();
+
+    @Redirect(method = "mobInteract", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/npc/Villager;getOffers()Lnet/minecraft/world/item/trading/MerchantOffers;"))
+    //MerchantOffers is a glorified ArrayList with extra functions for handling nbt. It has an isEmpty() method but remapping does NOT like it.
+    //So we return a separate empty list, doing so does not overwrite existing trades so if trades are re-enabled everything will be intact.
+    private MerchantOffers tradingCheck(Villager instance){
+        if(!CommonConfig.ENABLE_TRADING.get()) return packTweaker$EMPTY;
+        else return instance.getOffers();
+    }
+}

--- a/src/main/resources/packtweaker.mixins.json
+++ b/src/main/resources/packtweaker.mixins.json
@@ -3,8 +3,10 @@
   "minVersion": "0.8",
   "package": "com.killerqu.packtweaker.mixin",
   "compatibilityLevel": "JAVA_8",
-  "refmap": "PackTweaker.refmap.json",
-  "mixins": [],
+  "refmap": "packtweaker.refmap.json",
+  "mixins": [
+    "VillagerTradesMixin"
+  ],
   "client": [
     "ForgeIngameGuiMixin",
     "PauseScreenMixin"


### PR DESCRIPTION
Adds an option to common config
If disabled, villagers will always act as if they have no trades, regardless of the actual profession or rank of the villager.
Does not alter the villager's actual data, nor does it handle wandering traders.